### PR TITLE
remove isspmatrix_<fmt> use from codebase

### DIFF
--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -372,14 +372,12 @@ class bsr_array(_cs_matrix, _minmax_mixin):
         R,n = self.blocksize
 
         # convert to this format
-        if isspmatrix_bsr(other):
+        if isparse(other) and other.format == "bsr":
             C = other.blocksize[1]
         else:
             C = 1
 
-        from ._csr import isspmatrix_csr
-
-        if isspmatrix_csr(other) and n == 1:
+        if other.format == "csr" and n == 1:
             other = other.tobsr(blocksize=(n,C), copy=False)  # lightweight conversion
         else:
             other = other.tobsr(blocksize=(n,C))

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -89,20 +89,21 @@ class dia_array(_data_matrix):
     def __init__(self, arg1, shape=None, dtype=None, copy=False):
         _data_matrix.__init__(self)
 
-        if isspmatrix_dia(arg1):
-            if copy:
-                arg1 = arg1.copy()
-            self.data = arg1.data
-            self.offsets = arg1.offsets
-            self._shape = check_shape(arg1.shape)
-        elif issparse(arg1):
-            if arg1.format == self.format and copy:
-                A = arg1.copy()
+        if issparse(arg1)
+            if arg1.format == "dia":
+                if copy:
+                    arg1 = arg1.copy()
+                self.data = arg1.data
+                self.offsets = arg1.offsets
+                self._shape = check_shape(arg1.shape)
             else:
-                A = arg1.todia()
-            self.data = A.data
-            self.offsets = A.offsets
-            self._shape = check_shape(A.shape)
+                if arg1.format == self.format and copy:
+                    A = arg1.copy()
+                else:
+                    A = arg1.todia()
+                self.data = A.data
+                self.offsets = A.offsets
+                self._shape = check_shape(A.shape)
         elif isinstance(arg1, tuple):
             if isshape(arg1):
                 # It's a tuple of matrix dimensions (M, N)

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -246,20 +246,21 @@ class dok_array(_sparray, IndexMixin, dict):
                 if aij:
                     new[key] = aij
             # new.dtype.char = self.dtype.char
-        elif isspmatrix_dok(other):
-            if other.shape != self.shape:
-                raise ValueError("Matrix dimensions are not equal.")
-            # We could alternatively set the dimensions to the largest of
-            # the two matrices to be summed.  Would this be a good idea?
-            res_dtype = upcast(self.dtype, other.dtype)
-            new = self._dok_container(self.shape, dtype=res_dtype)
-            dict.update(new, self)
-            with np.errstate(over='ignore'):
-                dict.update(new,
-                           ((k, new[k] + other[k]) for k in other.keys()))
         elif issparse(other):
-            csc = self.tocsc()
-            new = csc + other
+            if other.format == "dok":
+                if other.shape != self.shape:
+                    raise ValueError("Matrix dimensions are not equal.")
+                # We could alternatively set the dimensions to the largest of
+                # the two matrices to be summed.  Would this be a good idea?
+                res_dtype = upcast(self.dtype, other.dtype)
+                new = self._dok_container(self.shape, dtype=res_dtype)
+                dict.update(new, self)
+                with np.errstate(over='ignore'):
+                    dict.update(new,
+                               ((k, new[k] + other[k]) for k in other.keys()))
+            else:
+                csc = self.tocsc()
+                new = csc + other
         elif isdense(other):
             new = self.todense() + other
         else:
@@ -274,16 +275,17 @@ class dok_array(_sparray, IndexMixin, dict):
                 aij = dict.get(self, (key), 0) + other
                 if aij:
                     new[key] = aij
-        elif isspmatrix_dok(other):
-            if other.shape != self.shape:
-                raise ValueError("Matrix dimensions are not equal.")
-            new = self._dok_container(self.shape, dtype=self.dtype)
-            dict.update(new, self)
-            dict.update(new,
-                       ((k, self[k] + other[k]) for k in other.keys()))
         elif issparse(other):
-            csc = self.tocsc()
-            new = csc + other
+            if other.format == "dok":
+                if other.shape != self.shape:
+                    raise ValueError("Matrix dimensions are not equal.")
+                new = self._dok_container(self.shape, dtype=self.dtype)
+                dict.update(new, self)
+                dict.update(new,
+                           ((k, self[k] + other[k]) for k in other.keys()))
+            else:
+                csc = self.tocsc()
+                new = csc + other
         elif isdense(other):
             new = other + self.todense()
         else:

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -87,7 +87,7 @@ class lil_array(_sparray, IndexMixin):
 
         # First get the shape
         if issparse(arg1):
-            if isspmatrix_lil(arg1) and copy:
+            if arg1.format == "lil" and copy:
                 A = arg1.copy()
             else:
                 A = arg1.tolil()

--- a/scipy/sparse/_spfuncs.py
+++ b/scipy/sparse/_spfuncs.py
@@ -3,8 +3,8 @@
 
 __all__ = ['count_blocks','estimate_blocksize']
 
-from ._csr import isspmatrix_csr, csr_array
-from ._csc import isspmatrix_csc
+from ._base import issparse
+from ._csr import csr_array
 from ._sparsetools import csr_count_blocks
 
 
@@ -14,7 +14,7 @@ def estimate_blocksize(A,efficiency=0.7):
     Returns a blocksize=(r,c) such that
         - A.nnz / A.tobsr( (r,c) ).nnz > efficiency
     """
-    if not (isspmatrix_csr(A) or isspmatrix_csc(A)):
+    if not (issparse(A) and A.format in ("csc", "csr")):
         A = csr_array(A)
 
     if A.nnz == 0:
@@ -67,10 +67,10 @@ def count_blocks(A,blocksize):
     if r < 1 or c < 1:
         raise ValueError('r and c must be positive')
 
-    if isspmatrix_csr(A):
-        M,N = A.shape
-        return csr_count_blocks(M,N,r,c,A.indptr,A.indices)
-    elif isspmatrix_csc(A):
-        return count_blocks(A.T,(c,r))
-    else:
-        return count_blocks(csr_array(A),blocksize)
+    if issparse(A):
+        if A.format == "csr":
+            M,N = A.shape
+            return csr_count_blocks(M,N,r,c,A.indptr,A.indices)
+        elif A.format == "csc":
+            return count_blocks(A.T,(c,r))
+    return count_blocks(csr_array(A),blocksize)

--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse import csr_matrix, issparse, isspmatrix_csc
+from scipy.sparse import csr_matrix, issparse
 from ._tools import csgraph_to_dense, csgraph_from_dense,\
     csgraph_masked_from_dense, csgraph_from_masked
 
@@ -17,7 +17,7 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
 
     # if undirected and csc storage, then transposing in-place
     # is quicker than later converting to csr.
-    if (not directed) and isspmatrix_csc(csgraph):
+    if (not directed) and issparse(csgraph) and csgraph.format == "csc":
         csgraph = csgraph.T
 
     if issparse(csgraph):

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -2,7 +2,7 @@ from warnings import warn
 
 import numpy as np
 from numpy import asarray
-from scipy.sparse import (isspmatrix_csc, isspmatrix_csr, issparse,
+from scipy.sparse import (issparse,
                           SparseEfficiencyWarning, csc_matrix, csr_matrix)
 from scipy.sparse._sputils import is_pydata_spmatrix
 from scipy.linalg import LinAlgError
@@ -209,7 +209,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     if is_pydata_spmatrix(A):
         A = A.to_scipy_sparse().tocsc()
 
-    if not (isspmatrix_csc(A) or isspmatrix_csr(A)):
+    if not (issparse(A) and A.format in ("csc", "csr")):
         A = csc_matrix(A)
         warn('spsolve requires A be CSC or CSR matrix format',
                 SparseEfficiencyWarning)
@@ -264,7 +264,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             b_is_sparse = False
 
         if not b_is_sparse:
-            if isspmatrix_csc(A):
+            if A.format == "csc":
                 flag = 1  # CSC format
             else:
                 flag = 0  # CSR format
@@ -281,7 +281,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
             # b is sparse
             Afactsolve = factorized(A)
 
-            if not (isspmatrix_csc(b) or is_pydata_spmatrix(b)):
+            if not (b.format == "csc" or is_pydata_spmatrix(b)):
                 warn('spsolve is more efficient when sparse b '
                      'is in the CSC matrix format', SparseEfficiencyWarning)
                 b = csc_matrix(b)
@@ -390,7 +390,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None,
     else:
         csc_construct_func = csc_matrix
 
-    if not isspmatrix_csc(A):
+    if not (issparse(A) and A.format == "csc"):
         A = csc_matrix(A)
         warn('splu converted its input to CSC format', SparseEfficiencyWarning)
 
@@ -482,7 +482,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     else:
         csc_construct_func = csc_matrix
 
-    if not isspmatrix_csc(A):
+    if not (issparse(A) and A.format == "csc"):
         A = csc_matrix(A)
         warn('spilu converted its input to CSC format',
              SparseEfficiencyWarning)
@@ -547,7 +547,7 @@ def factorized(A):
         if noScikit:
             raise RuntimeError('Scikits.umfpack not installed.')
 
-        if not isspmatrix_csc(A):
+        if not (issparse(A) and A.format == "csc"):
             A = csc_matrix(A)
             warn('splu converted its input to CSC format',
                  SparseEfficiencyWarning)
@@ -638,7 +638,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         A = A.to_scipy_sparse().tocsr()
 
     # Check the input for correct type and format.
-    if not isspmatrix_csr(A):
+    if not (issparse(A) and A.format == "csr"):
         warn('CSR matrix format is required. Converting to CSR matrix.',
              SparseEfficiencyWarning)
         A = csr_matrix(A)

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -38,7 +38,7 @@ Uses ARPACK: https://github.com/opencollab/arpack-ng
 import numpy as np
 import warnings
 from scipy.sparse.linalg._interface import aslinearoperator, LinearOperator
-from scipy.sparse import eye, issparse, isspmatrix_csr
+from scipy.sparse import eye, issparse
 from scipy.linalg import eig, eigh, lu_factor, lu_solve
 from scipy.sparse._sputils import isdense, is_pydata_spmatrix
 from scipy.sparse.linalg import gmres, splu
@@ -1038,7 +1038,7 @@ class IterOpInv(LinearOperator):
 
 def _fast_spmatrix_to_csc(A, hermitian=False):
     """Convert sparse matrix to CSC (by transposing, if possible)"""
-    if (isspmatrix_csr(A) and hermitian
+    if (A.format == "csr" and hermitian
             and not np.issubdtype(A.dtype, np.complexfloating)):
         return A.T
     elif is_pydata_spmatrix(A):


### PR DESCRIPTION
replaced isspmatrix_fmt use in the codebase for scipy.sparse.
Most changes are in the main space, but linalg and csgraph have a couple of small changes.